### PR TITLE
fix(dense-refactor): enforce left-associative subtraction

### DIFF
--- a/src/matrix/dense-refactor/operators/subtract.h
+++ b/src/matrix/dense-refactor/operators/subtract.h
@@ -24,8 +24,10 @@ struct DenseMatrixSubtractExpr {
     }
 
     std::common_type_t<typename ARGS::ValueType...> at(const std::size_t c, const std::size_t r) const {
-        return std::apply([c, r](const auto&... args) {
-            return (... - args[c, r]);
+        return std::apply([c, r](const auto& first, const auto&... rest) {
+            std::common_type_t<typename ARGS::ValueType...> value = first[c, r];
+            ((value -= rest[c, r]), ...);
+            return value;
         }, args);
     }
 

--- a/tests/matrix/dense/operators/subtract.tests.cpp
+++ b/tests/matrix/dense/operators/subtract.tests.cpp
@@ -73,3 +73,31 @@ TEST(dense_matrix_subtraction, given_f_and_cf_dense_matrices_should_return_diffe
     // assert
     ASSERT_TRUE(compare(Precision(0.001f), diff, expected));
 }
+
+TEST(dense_matrix_subtraction_operator, should_evaluate_left_associatively) {
+    // arrange
+    const DenseMatrix<float> a = {{10, 20}, {30, 40}};
+    const DenseMatrix<float> b = {{1, 2}, {3, 4}};
+    const DenseMatrix<float> c = {{5, 6}, {7, 8}};
+    const DenseMatrix<float> expected = {{4, 12}, {20, 28}};
+    // act
+    const DenseMatrix<float> left_associative = a - b - c;
+    const DenseMatrix<float> right_grouped = a - (b - c);
+    // assert
+    ASSERT_TRUE(compare(Precision(0.001f), left_associative, expected));
+    ASSERT_FALSE(compare(Precision(0.001f), left_associative, right_grouped));
+}
+
+TEST(dense_matrix_subtraction, should_evaluate_left_associatively) {
+    // arrange
+    const DenseMatrix<float> a = {{10, 20}, {30, 40}};
+    const DenseMatrix<float> b = {{1, 2}, {3, 4}};
+    const DenseMatrix<float> c = {{5, 6}, {7, 8}};
+    const DenseMatrix<float> expected = {{4, 12}, {20, 28}};
+    // act
+    const DenseMatrix<float> left_associative = subtract(a, b, c);
+    const DenseMatrix<float> explicit_left_grouped = subtract(subtract(a, b), c);
+    // assert
+    ASSERT_TRUE(compare(Precision(0.001f), left_associative, expected));
+    ASSERT_TRUE(compare(Precision(0.001f), left_associative, explicit_left_grouped));
+}


### PR DESCRIPTION
## Summary
- Fix dense subtraction expression evaluation to be explicitly left-associative.
- Add regression tests that lock in associativity behavior for chained subtraction.

## Changes
- src/matrix/dense-refactor/operators/subtract.h
  - Replace fold subtraction with explicit first/rest accumulation (`value -= ...`) to preserve `(a - b) - c` semantics.
- tests/matrix/dense/operators/subtract.tests.cpp
  - Add associativity-focused tests for operator and helper paths.

## Issue
Closes #220

## Validation
- Full test build currently fails in this branch due pre-existing ambiguous chained operator overload resolution in dense add/subtract/multiply tests; this PR is scoped to issue #220.
