### PR TITLE
fix(dense-refactor): use size_t loop indices in dense operators

### DIFF
--- a/src/matrix/dense-refactor/operators/add_assign.h
+++ b/src/matrix/dense-refactor/operators/add_assign.h
@@ -6,11 +6,11 @@ template<dense_matrix_like T, dense_matrix_like U> requires has_common_type<type
 T& add_assign(T& a, const U& b) {
     assert_same_dimensions(a, b);
 
-    const int columns = a.columns();
-    const int rows = a.rows();
+    const std::size_t columns = a.columns();
+    const std::size_t rows = a.rows();
 
-    for (int c = 0; c < columns; c++) {
-        for (int r = 0; r < rows; r++) {
+    for (std::size_t c = 0; c < columns; c++) {
+        for (std::size_t r = 0; r < rows; r++) {
             a[c, r] += b[c, r];
         }
     }

--- a/src/matrix/dense-refactor/operators/compare.h
+++ b/src/matrix/dense-refactor/operators/compare.h
@@ -12,11 +12,11 @@ template<dense_matrix_like T, dense_matrix_like U, dense_matrix_like... ARGS> re
 [[nodiscard]] bool compare(const Precision<underlying_type_t<std::common_type_t<typename T::ValueType, typename ARGS::ValueType...>>> precision, const T& a, const U& b, const ARGS&... args) {
     assert_same_dimensions(a, b, args...);
 
-    const int columns = a.columns();
-    const int rows = a.rows();
+    const std::size_t columns = a.columns();
+    const std::size_t rows = a.rows();
 
-    for (int c = 0; c < columns; c++) {
-        for (int r = 0; r < rows; r++) {
+    for (std::size_t c = 0; c < columns; c++) {
+        for (std::size_t r = 0; r < rows; r++) {
             if (!compare(precision, a[c, r], b[c, r], args[c, r]...)) {
                 return false;
             }

--- a/src/matrix/dense-refactor/operators/multiply.h
+++ b/src/matrix/dense-refactor/operators/multiply.h
@@ -56,17 +56,17 @@ struct DenseMatrixMultiplyExpr {
 private:
     template<dense_matrix_like T, dense_matrix_like U>
     static DenseMatrix<std::common_type_t<typename ARGS::ValueType...>> multiply(const T& a, const U& b) {
-        const int aRows = a.rows();
-        const int aColumns = a.columns();
-        const int bColumns = b.columns();
+        const std::size_t a_rows = a.rows();
+        const std::size_t a_columns = a.columns();
+        const std::size_t b_columns = b.columns();
 
-        DenseMatrix<std::common_type_t<typename ARGS::ValueType...>> result(aRows, bColumns, false);
+        DenseMatrix<std::common_type_t<typename ARGS::ValueType...>> result(a_rows, b_columns, false);
 
-        for (int c = 0; c < bColumns; c++) {
-            for (int r = 0; r < aRows; r++) {
+        for (std::size_t c = 0; c < b_columns; c++) {
+            for (std::size_t r = 0; r < a_rows; r++) {
                 result[c, r] = 0;
 
-                for (int x = 0; x < aColumns; x++) {
+                for (std::size_t x = 0; x < a_columns; x++) {
                     result[c, r] += a[x, r] * b[c, x];
                 }
             }

--- a/tests/matrix/dense/operators/add_equals.tests.cpp
+++ b/tests/matrix/dense/operators/add_equals.tests.cpp
@@ -73,3 +73,14 @@ TEST(dense_matrix_addition_assignment, given_f_and_cf_dense_matrices_should_add_
     // assert
     ASSERT_TRUE(compare(Precision(0.001f), a, expected));
 }
+
+TEST(dense_matrix_addition_assignment, given_rectangular_dense_matrices_should_add_assign) {
+    // arrange
+    DenseMatrix<float> a = {{1, 10}, {2, 20}, {3, 30}, {4, 40}};
+    const DenseMatrix<float> b = {{5, 50}, {6, 60}, {7, 70}, {8, 80}};
+    const DenseMatrix<float> expected = {{6, 60}, {8, 80}, {10, 100}, {12, 120}};
+    // act
+    add_assign(a, b);
+    // assert
+    ASSERT_TRUE(compare(Precision(0.001f), a, expected));
+}

--- a/tests/matrix/dense/operators/compare.tests.cpp
+++ b/tests/matrix/dense/operators/compare.tests.cpp
@@ -265,3 +265,16 @@ TEST(dense_matrix_equality, given_f_and_cf_dense_matrices_and_precision_should_r
     // assert
     ASSERT_FALSE(result);
 }
+
+TEST(dense_matrix_equality, given_rectangular_dense_matrices_should_compare_correctly) {
+    // arrange
+    const DenseMatrix<float> a = {{1, 10}, {2, 20}, {3, 30}, {4, 40}};
+    const DenseMatrix<std::complex<float>> b = {{{1, 0}, {10, 0}}, {{2, 0}, {20, 0}}, {{3, 0}, {30, 0}}, {{4, 0}, {40, 0}}};
+    const DenseMatrix<float> c = {{1, 10}, {2, 20}, {3, 30}, {4, 41}};
+    // act
+    const bool equal_result = compare(a, b);
+    const bool precision_result = compare(Precision(0.5f), a, c);
+    // assert
+    ASSERT_TRUE(equal_result);
+    ASSERT_FALSE(precision_result);
+}

--- a/tests/matrix/dense/operators/multiply.tests.cpp
+++ b/tests/matrix/dense/operators/multiply.tests.cpp
@@ -73,3 +73,16 @@ TEST(dense_matrix_multiplication, given_f_and_cf_dense_matrices_should_return_pr
     // assert
     ASSERT_TRUE(compare(Precision(0.001f), product, expected));
 }
+
+TEST(dense_matrix_multiplication, given_single_row_and_single_column_should_return_dot_product) {
+    // arrange
+    const DenseMatrix<float> a = {{1}, {2}, {3}, {4}};
+    const DenseMatrix<float> b = {{10, 20, 30, 40}};
+    const DenseMatrix<float> expected = {{300}};
+    // act
+    const DenseMatrix<float> product_operator = a * b;
+    const DenseMatrix<float> product_function = multiply(a, b);
+    // assert
+    ASSERT_TRUE(compare(Precision(0.001f), product_operator, expected));
+    ASSERT_TRUE(compare(Precision(0.001f), product_function, expected));
+}


### PR DESCRIPTION
## Summary
- Replace `int` dimension locals and loop counters with `std::size_t` in dense-refactor operator implementations.
- Add regression coverage for rectangular/edge-shape matrix paths to validate updated loops.

## Code Changes
- src/matrix/dense-refactor/operators/multiply.h
- src/matrix/dense-refactor/operators/add_assign.h
- src/matrix/dense-refactor/operators/compare.h

## Test Changes
- tests/matrix/dense/operators/add_equals.tests.cpp
  - Added rectangular add-assign coverage.
- tests/matrix/dense/operators/compare.tests.cpp
  - Added rectangular compare coverage.
- tests/matrix/dense/operators/multiply.tests.cpp
  - Added single-row x single-column dot-product coverage.

## Validation
- Attempted full build with `cmake --build build -- -j$(nproc)`.
- Build is currently blocked by pre-existing ambiguous operator overload errors in chained dense add/subtract/multiply tests (outside this issue scope).

Closes #222
